### PR TITLE
 Don't use secure cookies in dev mode

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -74,7 +74,7 @@ class App {
          */
         cookie: {
           maxAge: cookieExpiry * 1000,
-          secure: true,
+          secure: process.env.NODE_ENV === 'production' ? true : false,
           sameSite: 'none',
         },
         rolling: true,


### PR DESCRIPTION
session with cookies  secure property set to true don't allow setting cookies coming from different domain, but we want this as while testing vega frontend and backend in dev mode both are on different domain and still we would like to test them both combined.